### PR TITLE
Always link/mention people in messages

### DIFF
--- a/src/awesome_o/slack.clj
+++ b/src/awesome_o/slack.clj
@@ -14,6 +14,7 @@
 (defn say [stuff & {:keys [channel username emoji]}]
   (http/post (channel->token (or channel "general"))
              {:text stuff
+              :link_names 1
               :username (or username "awesome-o")
               :icon_emoji (or emoji ":awesomeo:")}))
 


### PR DESCRIPTION
As deeply hidden in the manual
(https://api.slack.com/docs/message-formatting#parsing_modes), instead
of using the weird `<U12345>` syntax to mention users, setting
`link_names=1` in the payload will automatically mention users.

This could be useful e.g. for the random-meeting functionality :)