### PR TITLE
Allow adding users when other users have an undefined position

### DIFF
--- a/test/awesome_o/bot_test.clj
+++ b/test/awesome_o/bot_test.clj
@@ -57,6 +57,29 @@
     (is (or (= meeting ["Today's random meeting is between @kristoffer and @jean-louis"])
             (= meeting ["Today's random meeting is between @jean-louis and @kristoffer"])))))
 
+(deftest test-add-person-to-state-fn
+  (testing "resilience to people not having a defined position"
+    (let [state {:persons {"albert"  {:birthday "1993-10-22"
+                                      :location "stockholm"
+                                      :team     nil
+                                      :away     []
+                                      :position 1}
+                           "bertha"  {:birthday "1987-03-13"
+                                      :location "berlin"
+                                      :team     "dev"
+                                      :away     []
+                                      ;; position key should always be present
+                                      }}}
+          add-to-state (state/add-person-to-state-fn "catherine")]
+      (is (= {:birthday nil
+              :location nil
+              :team nil
+              :away []
+              :position 2}
+             (-> (add-to-state state)
+                 :persons
+                 (get "catherine")))))))
+
 (deftest random-triple-meeting-test
   (testing "A random meeting between three people from different locations"
     (let [location-of-people {"magnus"     "göteborg"


### PR DESCRIPTION
The position of each person in the state seems to be required, but one of our users in state didn't have any.
The faulty user is particularly odd and seems to have been added by some unusual means to the state. The data that existed for this user was the following:

```
"nathan" {:away ({:from "2017-12-25", :to "2018-01-02"})}
```

While this user has a list representing the `:away` intervals, all the others have a vector. The user also does not have any default values on the remaining fields, while all others do.

This change makes the adding users work in the presence of that data, but we will also remove it from the state to ensure that it doesn't break things elsewhere.